### PR TITLE
Add headers to comply with GCC 13

### DIFF
--- a/source/include/trace/Types.hpp
+++ b/source/include/trace/Types.hpp
@@ -3,6 +3,7 @@
 #include <stdio.h>
 #include <unistd.h>
 #include <iostream>
+#include <cstdint>
 
 #if OS_TARGET == OS_ANDROID
    #include <android/log.h>

--- a/source/random.cpp
+++ b/source/random.cpp
@@ -4,6 +4,7 @@
 
 
 #include <unistd.h>
+#include <ctime>
 
 #include "random.hpp"
 

--- a/source/trace/Types.cpp
+++ b/source/trace/Types.cpp
@@ -4,6 +4,7 @@
 
 
 #include <cstring>
+#include <cstdint>
 
 #include "trace/Types.hpp"
 


### PR DESCRIPTION
GCC 13 requires some headers to be included explicitly. See https://gcc.gnu.org/gcc-13/porting_to.html for details.