### PR TITLE
Fix dangling pointer and UB in address retrieval

### DIFF
--- a/source/client.cpp
+++ b/source/client.cpp
@@ -57,9 +57,10 @@ namespace client {
          }
          case AF_INET:
          {
-            const char* address_cstr = parameters->value_or< std::string >(
+            std::string address_str = parameters->value_or<std::string>(
                   "address", common::default_values::address_inet
-               ).first.c_str( );
+               ).first;
+            const char* address_cstr = address_str.c_str();
             in_addr address_buf;
             int result = inet_pton( AF_INET, address_cstr, (char*)&address_buf );
             if( 0 == result )


### PR DESCRIPTION
This patch resolves issue leading to Undefined Behavior (UB) caused by a dangling pointer. Previously, `c_str()` was called directly on a temporary `std::string` object returned by `parameters->value_or(...)`. Because the temporary object was immediately destroyed at the end of the statement, the resulting `const char*` pointed to deallocated memory.