### PR TITLE
fix(android): enable trace logging

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -18,6 +18,12 @@ cc_binary {
         "-Wno-ignored-qualifiers",
         "-Wno-unused-private-field",
         "-Wno-unused-variable",
+
+        "-DOS_LINUX=0",
+        "-DOS_ANDROID=1",
+        "-DOS_TARGET=OS_ANDROID",
+        "-DMSG_TRACE",
+        "-DCOLORED_TRACE",
     ],
     local_include_dirs: ["source/include"],
 }


### PR DESCRIPTION
Restore trace output on Android (console/logcat).

The issue was caused by missing compiler definitions and Android.bp configuration, which prevented the correct logging strategy from being selected at compile time.